### PR TITLE
Header hide on scroll

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,9 +1,27 @@
 <script>
   import { page } from "$app/stores";
   import { base } from "$app/paths";
+
+  export let scrollY;
+
+  let hide = false;
+  let lastScrollY;
+
+  // $: clipHeight = hide ? "0px" : "56px";
+
+  $: if (!hide && scrollY > lastScrollY) {
+    hide = true;
+    lastScrollY = scrollY;
+  } else if (hide && scrollY < lastScrollY) {
+    hide = false;
+    lastScrollY = scrollY;
+  } else {
+    lastScrollY = scrollY;
+  }
 </script>
 
-<header class="site-header">
+<header class="site-header" class:hide>
+  <div class="site-header-background"></div>
   <div class="site-header-wrapper">
     <label for="nav-trigger" class="menu-icon">
       <svg viewBox="0 0 18 15" width="18px" height="15px">
@@ -41,12 +59,12 @@
       </span>
       <a
         class="page-link"
-        class:active={$page.route.id == "/blog"}
+        class:active={$page.route.id.includes("blog")}
         href="{base}/blog">blog</a
       >
       <a
         class="page-link"
-        class:active={$page.route.id == "/about"}
+        class:active={$page.route.id.includes("about")}
         href="{base}/about">about</a
       >
     </nav>
@@ -60,10 +78,40 @@
   @use "../styles/colors" as *;
   @use "../styles/variables" as *;
 
+  $header-background-opacity: .85;
+
   .site-header {
-    position: relative;
+    position: fixed;
+    top: 0;
     width: 100vw;
     z-index: 2;
+  }
+
+  #toggle {
+    position: fixed;
+    top: 100px;
+    left: 100px;
+  }
+
+  :global(.site-header-background) {
+    background-color: $white-color;
+    clip-path: polygon(0 0, 100% 0, 100% 56px, 0 56px);
+    pointer-events: none;
+    position: fixed;
+    height: 100vh;
+    opacity: $header-background-opacity;  
+    transition: opacity .3s;
+    width: 100vw;
+    z-index: -1;
+
+    .hide & {
+      opacity: 0;
+    }
+  }
+
+  :global(.home .site-header-background) {
+      background-color: transparent;
+      background-image: $radial-red;
   }
 
   .site-header-wrapper {
@@ -71,12 +119,26 @@
     display: flex;
     font-size: 18px;
     height: 56px;
-    margin: 0 20px;
+    padding: 0 20px;
+    transform: translateY(0%);
+    transition: transform .3s;
+
+    .hide & {
+      transform: translateY(-100%);
+    }
 
     @media (min-width: 768px) {
       flex-direction: row-reverse;
       justify-content: space-between;
     }
+  }
+
+  .site-header:hover .site-header-wrapper {
+    transform: translate(0%);
+  }
+
+  .site-header:hover .site-header-background {
+    opacity: $header-background-opacity;
   }
 
   .menu-icon {

--- a/src/lib/styles/_colors.scss
+++ b/src/lib/styles/_colors.scss
@@ -17,3 +17,5 @@ $gray-color-dark: darken($gray-color, 25%);
 
 $red-color-dark: #440000;
 $red-color-light: #aa0000;
+
+$radial-red: radial-gradient($red-color-light, $red-color-dark);

--- a/src/lib/styles/_layout.scss
+++ b/src/lib/styles/_layout.scss
@@ -2,7 +2,7 @@
 @use "colors" as *;
 
 .page-content {
-  margin: 0;
+  margin: 100px 0 0;
 
   h3 {
     margin: 1.5em 0 0.5em;
@@ -29,6 +29,8 @@
   }
 
   &.portfolio {
+    padding: 0 20px;
+
     .column {
       &.content {
         margin-bottom: 30px;
@@ -74,6 +76,7 @@
   font-weight: 300;
   justify-content: space-between;
   margin: 40px 0 20px;
+  padding: 0 20px;
   min-height: 38px;
 
   h5 {
@@ -313,7 +316,7 @@ figure {
 
 /* HOME PAGE */
 .home {
-  background-image: radial-gradient($red-color-light, $red-color-dark);
+  background-image: $radial-red;
 
   .site-footer {
     #twitter-icon {
@@ -403,6 +406,10 @@ figure {
 }
 
 @media only screen and (min-width: 480px) {
+  .page-content {
+    margin-top: 120px;
+  }
+
   .thumbnails-grid {
     grid-gap: 36px;
     grid-template-columns: 1fr 1fr 1fr;
@@ -422,7 +429,7 @@ figure {
     &.portfolio {
       display: flex;
       flex-direction: row-reverse;
-      padding: 0 0 20px;
+      padding: 0 20px 20px;
 
       .column {
         &.text {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
   import "$lib/styles/style.scss";
 
   let main;
+  let scrollY;
 
   $: if (browser) {
     if ($page.route.id == "/") {
@@ -17,9 +18,9 @@
   }
 </script>
 
-<Header />
+<Header {scrollY} />
 
-<main class="page-wrapper" bind:this={main}>
+<main class="page-wrapper" bind:this={main} on:scroll={() => scrollY = main.scrollTop}>
   {#if $page.route.id == "/"}
     <section class="animated-background" />
   {/if}
@@ -84,16 +85,11 @@
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
-    height: calc(100% - 56px);
+    height: 100%;
     justify-content: space-between;
     overflow-y: auto;
-    padding: 30px 20px 0;
     position: relative;
     width: 100%;
     z-index: 1;
-
-    @media (min-width: 480px) {
-      padding-top: 50px;
-    }
   }
 </style>

--- a/src/routes/graphics/[slug]/+page.svelte
+++ b/src/routes/graphics/[slug]/+page.svelte
@@ -3,7 +3,7 @@
   export let data;
 </script>
 
-<div class="page-content graphics">
+<div class="page-content portfolio">
   <section class="column content">
     {#each data.images as image}
       <img class="graphics-image" src="{base}/img/{image}" alt={data.title} />

--- a/src/routes/illustrations/[slug]/+page.svelte
+++ b/src/routes/illustrations/[slug]/+page.svelte
@@ -3,7 +3,7 @@
   export let data;
 </script>
 
-<div class="page-content illustrations">
+<div class="page-content portfolio">
   <section class="column content">
     {#each data.images as image}
       <img class="illustrations-image" src="{base}/img/{image}" alt={data.title} />


### PR DESCRIPTION
## Changes

* Adds missing `portfolio` class to graphics and illustrations to fix broken layout
* Makes `Header` component show/hide on page scroll and hover
* Moves space around content from `.page-wrapper` padding to `.page-content` margin.